### PR TITLE
Make dev-tools shebang file generic for different users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,14 @@
 - Run `composer install` inside the `./dev-tools/` directory.
 - Run `cp ./dev-tools/.env.example ./dev-tools/.env`
   - Fill in and change details as appropriate
-- Add the bin directory to $PATH in your .bashrc
-  - e.g.: `export PATH=$PATH:/home/$USER/local-dev/bin`
+- Add the bin directory to $PATH.
+  | Shell           | Command                                                                     |
+  | --------------- | --------------------------------------------------------------------------- |
+  | BASH            | `export PATH=$PATH:$HOME/local-dev/dev-tools/bin`                     |
+  | BASH Permanent  | `echo 'export PATH=$PATH:$HOME/local-dev/dev-tools/bin' >> ~/.bashrc` |
+  | Fish            | `fish_add_path $HOME/local-dev/dev-tools/bin`                         |
+  | ZSH             | `export PATH=$PATH:$HOME/local-dev/dev-tools/bin`                     |
+  | ZSH Permanent   | `echo 'export PATH=$PATH:$HOME/local-dev/dev-tools/bin' >> ~/.zshrc`  |
 
 ## Usage
 - Run `dev-tools list` to see available commands and usage.

--- a/bin/dev-tools
+++ b/bin/dev-tools
@@ -1,1 +1,0 @@
-/home/gsartorelli/local-dev/dev-tools/dev-tools

--- a/dev-tools/bin/dev-tools
+++ b/dev-tools/bin/dev-tools
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
 use DevTools\Command;
 use DevTools\Utility\Config;


### PR DESCRIPTION
The kernel handles symlinks and doesn't support environment variables so we can simply change the symlink to `$HOME/...` etc.

IIRC `~` (tilde) is expanded outside the kernel as well so also won't work.

There might be a way but this is easier!

I haven't even booted yet so let me know if this will break something else or just close if you cba rearranging your local setup :)